### PR TITLE
update library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/api/) - A JavaScript & WebGL library that renders interactive maps from vector tiles and the Mapbox GL Style Specification
 - [OpenLayer3](http://openlayers.org/) - Open-source javascript map viewing library
 - [three.js](http://threejs.org/) - A javascript 3D library which makes WebGL simpler
-- [cesiumjs](https://cesiumjs.org/) - An open-source JavaScript library for world-class 3D globes and maps
+- [CesiumJS](https://cesiumjs.org/) - An open-source JavaScript library for world-class 3D globes and maps
 - [webglearth2](https://github.com/webglearth/webglearth2) - Open-source virtual planet web application running in any web browser with support for WebGL HTML5 standard
 - [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/) - Creating high-performing apps and smarter visualizations supportted by ERSI
 - [D3.js](https://d3js.org/) - A javascript library for manipulating documents based on data


### PR DESCRIPTION
Cesium, the JavaScript library, is now officially renamed to CesiumJS