### PR TITLE
Added ArcGIS Online as SaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 
 ### SaaS
 - [Mapbox](https://www.mapbox.com/) - Helping you design your own map and presenting your data
+- [ArcGIS Online](https://developers.arcgis.com/) - Thousands of datasets and dozens of tools to manipulate, analyze and present data.
 - [Cartodb](http://cartodb.com/) - The easiest way to map and analyze your location data
 - [GIS Cloud](http://www.giscloud.com/) - A next generation platform for apps that manage location information
 - [stamen](http://stamen.com/) - Data visualization to tell compelling stories for some of the world's most visible companies


### PR DESCRIPTION
ArcGIS Online product is hosted under *.arcgis.com, so it has many subdomains: developers.arcgis.com, livingatlas.arcgis.com, etc. I have just added [a comment](https://github.com/sshuair/awesome-gis/commit/13e2d56d41adc1a0c4a5df59139db737d08f5d3d#r36589341) to clarify this because "www.arcgis.com" is already  included. And instead of adding www.arcgis.com which is a mainly used as a "login interface", I think it is most useful to include the developers landings page on this repo because I think Github users would probably appreciate more the link to the site that is build by Esri developers for developers (and also include the link to the free developer account). Does it make sense?