### PR TITLE
Proposal for a new description and link for ArcGIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 
 ----
 
-## Geographic Information System Desktop Software
+## Geographic Information System Software
 - [ArcGIS Desktop](https://www.esri.com/en-us/arcgis/products/arcgis-desktop/overview): Extendable desktop suite to manage, visualize and analyze GIS data in 2D and 3D, including image processing. Includes ArcGIS Pro, ArcMap, ArcCatalog, and ArcGIS Online.
 - [QGIS](http://qgis.org/en/site/) :star2: - A free and open source GIS.
 - [GeoDa](http://geodacenter.github.io/) - A free and open source software tool that serves as an introduction to spatial data analysis.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 ----
 
 ## Geographic Information System Software
-- [ArcGIS](https://www.arcgis.com/) :star2: - An enterprise-level desktop GIS software published by Esri.
+- [ArcGIS](https://www.esri.com/arcgis/) :star2: - Cross-platform with free, open and paid data and mapping tools, APIs, SDKs, etc.
 - [QGIS](http://qgis.org/en/site/) :star2: - A free and open source GIS.
 - [GeoDa](http://geodacenter.github.io/) - A free and open source software tool that serves as an introduction to spatial data analysis.
 - [GISInternals](http://www.gisinternals.com/) - Povidesdaily build packages and software development kits for the GDAL and MapServer

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 
 ----
 
-## Geographic Information System Software
-- [ArcGIS](https://www.esri.com/arcgis/) :star2: - Cross-platform with free, open and paid data and mapping tools, APIs, SDKs, etc.
+## Geographic Information System Desktop Software
+- [ArcGIS Desktop](https://www.esri.com/en-us/arcgis/products/arcgis-desktop/overview): Extendable desktop suite to manage, visualize and analyze GIS data in 2D and 3D, including image processing. Includes ArcGIS Pro, ArcMap, ArcCatalog, and ArcGIS Online.
 - [QGIS](http://qgis.org/en/site/) :star2: - A free and open source GIS.
 - [GeoDa](http://geodacenter.github.io/) - A free and open source software tool that serves as an introduction to spatial data analysis.
 - [GISInternals](http://www.gisinternals.com/) - Povidesdaily build packages and software development kits for the GDAL and MapServer


### PR DESCRIPTION
As I mentioned on [this comment](https://github.com/sshuair/awesome-gis/commit/13e2d56d41adc1a0c4a5df59139db737d08f5d3d#r36589341), I wouldn't describe ArcGIS like "a desktop GIS software" anymore, and the link is pointing to "www.arcgis.com" which is the landing page for "ArcGIS Online", the cloud service, the official page is [esri.com/arcgis](https://www.esri.com/arcgis).

I have spent some time working [a diagram to describe the ecosystem of technologies that form the Esri platform](https://docs.google.com/drawings/d/1w_tBCVPdPULUehfFBJaqyH7ywZyxZLBCeemWFa3o2Ho/edit?usp=sharing), and based on my experience, I think it would make more sense to change the description to "Cross-platform with free, open and paid data and mapping tools, APIs, SDKs, etc."? 

> Note: I would include "free" because there are more than 7000 curated datasets than can be used for free, but also a developer account that allow to use ArcGIS Online with 10 SDKs, 5 app builders, etc, [for free](https://developers.arcgis.com/pricing/) with a pay-as-you-go model that includes monthly credits to use APIs for free (for example to host +200MB of data in the free account).

Cheers!