### PR TITLE
Remove GISbiz

### DIFF
--- a/Geospatial-Start-ups-And-Companies.md
+++ b/Geospatial-Start-ups-And-Companies.md
@@ -34,7 +34,6 @@
 |   [Garmin](http://www.garmin.com/garmin/cms/site/us)  |   Navigation  |   Olathe, KS  |   US  |   1989    |
 |   [Geofeedia](http://geofeedia.com/)  |   LBMarketing |   Chicago, IL |   US  |   2011    |
 |   [Geoloqi](http://geoloqi.com/)  |   Maps    |   Portland, OR    |   US  |   2010    |
-|   [GISbiz](http://www.gisbiz.com/)   |   Consulting |   Nashville, TN  |   US  |   2003    |
 |   [GIS Cloud](http://www.giscloud.com/)   |   GIS |   London  |   UK  |   2008    |
 |   [Google](http://www.google.com/)    |   Maps    |   Mountain View, CA   |   US  |   1998    |
 |   [HERE](http://here.com/)    |   Maps    |   Eindhoven  |   Netherlands |   2012    |


### PR DESCRIPTION
GISbiz was rebranded to kanini.com about 2 years ago, and Kanini does not do much work in GIS (source: I'm Director of App Development at Kanini).