### PR TITLE
Add Geomob podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [Eyes on Earth](https://www.usgs.gov/centers/eros/science/eyes-earth)
 - [Geodorable Podcast](https://geodorable.com/)
 - [Geointeresting](https://podcasts.apple.com/us/podcast/geointeresting/id990858116)
+- [Geomob podcast](https://thegeomob.com/podcast)
 - [Geospatially Podcast](https://projectgeospatially.github.io/podcast/)
 - [Isin't That Spatial](https://isntthatspatial.net/)
 - [Map Shack](https://blog.mapspeople.com/introducing-the-map-shack-a-mapspeople-podcast)


### PR DESCRIPTION
Geomob is a weekly podcast with over 200 episodes. Each week discuss themes from the geo industry or interview Geomob event speakers