### PR TITLE
Add halfmaps to 3D applications list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [DEM Net Elevation API](https://elevationapi.com) - 3D terrain model generation online from open data (DEM, OSM) and imagery, exports to STL and glTF.
 - [Earth Enterprise](https://github.com/google/earthenterprise) - the open source release of Google Earth Enterprise, a geospatial application which provides the ability to build and host custom 3D globes and 2D maps.
 - [Google Earth](http://earth.google.com/) - A computer program that renders a 3D representation of Earth based on satellite imagery.
+- [halfmaps](https://www.halfmaps.io/) - 3D map exporter that converts real-world geospatial data into models for CAD, GIS, and 3D workflows, with export formats like GLTF, OBJ, STL, and 3MF.
 - [Skyline](http://www.skylineglobe.com/SkylineGlobe/corporate/Default.aspx?) - 3D desktop and web-based applications, enabling an enterprise to build, edit, navigate, query, and analyze realistic 3D environments.
 - [World Wind](http://worldwind.arc.nasa.gov/java/) -  An SDK (software development kit) that software engineers can use to build their own applications
 - [LAStools](https://rapidlasso.de/product-overview/) -  A collection of 52 highly efficient, batch-scriptable, multicore command-line tools for processing point clouds. The tools can also be run via a native GUI (laslook) and are available as toolboxes (QGIS, ArcGIS Pro, FME, Erdas)
-- [Vectiler](https://www.halfmaps.io) - 3D model generation from vector tile and raster sources (DEM-raster, MVT, Geojson), exports to glTF, STL, 3MF, OBJ.
 
 ## Web Map Servers
 - [ArcGIS Server](http://server.arcgis.com/) - A GIS server for enterprise application.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [Skyline](http://www.skylineglobe.com/SkylineGlobe/corporate/Default.aspx?) - 3D desktop and web-based applications, enabling an enterprise to build, edit, navigate, query, and analyze realistic 3D environments.
 - [World Wind](http://worldwind.arc.nasa.gov/java/) -  An SDK (software development kit) that software engineers can use to build their own applications
 - [LAStools](https://rapidlasso.de/product-overview/) -  A collection of 52 highly efficient, batch-scriptable, multicore command-line tools for processing point clouds. The tools can also be run via a native GUI (laslook) and are available as toolboxes (QGIS, ArcGIS Pro, FME, Erdas)
+- [Vectiler](https://www.halfmaps.io) - 3D model generation from vector tile and raster sources (DEM-raster, MVT, Geojson), exports to glTF, STL, 3MF, OBJ.
 
 ## Web Map Servers
 - [ArcGIS Server](http://server.arcgis.com/) - A GIS server for enterprise application.


### PR DESCRIPTION
Add [halfmaps](https://www.halfmaps.io/) 3D map exporter that converts real-world geospatial data into models for CAD, GIS, and 3D workflows, with export formats like GLTF, OBJ, STL, and 3MF to the list of 3D software