### PR TITLE
Add ZipCheckup to Data Site section

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
     - [T-Drive trajectory data sample](http://research.microsoft.com/apps/pubs/default.aspx?id=152883)
     - [USGS Remote Sensing Image](http://earthexplorer.usgs.gov/)
     - [WorldPop](http://www.worldpop.org.uk/)
+    - [ZipCheckup](https://zipcheckup.com/) - Free ZIP-level environmental data platform with 17 verticals (water quality, air quality, PFAS, radon, flood risk) for 42K US ZIP codes. Public API, CC BY 4.0.
 
 ## News Sites
 - [canadiangis](http://canadiangis.com/)


### PR DESCRIPTION
ZipCheckup is a free public data platform providing ZIP-level environmental safety data for the United States. Aggregates 50+ federal data sources (EPA, CDC, USGS, FEMA) across 17 safety verticals. Public REST API at api.zipcheckup.com/v1/. Open data CC BY 4.0.

Added to **Data Site** section in alphabetical order (after WorldPop).