### PR TITLE
Add Japan Neighborhoods Crime Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [dougmccune](http://dougmccune.com/blog/)
 - [finemapping](http://www.finemapping.com/)
 - [flowingdata](http://flowingdata.com/)
+- [Japan Neighborhoods Crime Map](https://japanneighborhoods.com/guides/tokyo-crime-map) - Interactive Leaflet crime safety map of 5,078 Tokyo neighborhoods, color-coded by safety grade (A+ to F), sourced from Tokyo Metropolitan Police open data (2018-2024).
 - [Maps of the Year](http://homepage.ntlworld.com/keir.clarke/mapsoftheyear.htm)
 - [mapzilla](https://mapzilla.co.uk/)
 - [NC STATE UNIVERSITY Center for Geospatial Analytics](https://cnr.ncsu.edu/geospatial/)


### PR DESCRIPTION
Adds interactive Leaflet crime map of 5,078 Tokyo neighborhoods to Amazing Map Sites. Color-coded by safety grade, sourced from Tokyo Metropolitan Police open data. https://japanneighborhoods.com/guides/tokyo-crime-map