### PR TITLE
Add Road511 to Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
     - [NYC Taxi & Limousine Commission - Trip Record Data](http://www.nyc.gov/html/tlc/html/about/trip_record_data.shtml)
     - [OpenFlights: Airport and airline data](http://openflights.org/data.html)
     - [Open Street Map](https://www.openstreetmap.org/) - A map of the world, created by people like you and free to use under an open license.
+    - [Road511](https://road511.com) - Real-time traffic data API aggregating 511 systems from 65 US states and Canadian provinces (events, cameras, bridges, truck routes, GeoJSON-native).
     - [pm2.5-China](http://www.pm25.in/)
     - [T-Drive trajectory data sample](http://research.microsoft.com/apps/pubs/default.aspx?id=152883)
     - [USGS Remote Sensing Image](http://earthexplorer.usgs.gov/)


### PR DESCRIPTION
Adds Road511 to the `## Data` → **Data Site** subsection, alphabetically placed after "Open Street Map".

Road511 is a unified REST + GeoJSON API that normalizes real-time traffic data from 65 US state and Canadian province 511 systems — traffic events, cameras, DMS signs, bridge clearances, truck routes, weight restrictions, weather stations, EV charging. Every list endpoint has a GeoJSON variant that drops directly into Leaflet, Mapbox, MapLibre, QGIS.

- Docs: https://road511.com/docs.html
- Live map: https://map.road511.com
- OpenAPI spec: https://api.road511.com/api/v1/docs/doc.json
- Free tier: 14-day trial, 1,000 requests/day, 2 jurisdictions (no credit card)

Follows the existing Data Site entry format: `[Name](url) - short description.`