### PR TITLE
Add Crime Brasil to Data > Data Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,8 +967,6 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
     - [GeoCommons ](http://geocommons.com/) - A community contributed collection of open data from around the world
 
 - **Data Site**
-    - [Citi Bike Trip Histories](https://www.citibikenyc.com/system-data)
-    - [Crime Brasil](https://crimebrasil.com.br) - Brazilian crime incidents geocoded by neighborhood (RS, 2.99M records) and municipality (MG, RJ) with free REST API.
     - [Geofabrik](http://download.geofabrik.de/)
     - [Geo Maps](https://github.com/simonepri/geo-maps) - High Quality GeoJSON maps programmatically generated.
     - [Global cities Shapefile data](http://download.bbbike.org/osm/bbbike/)
@@ -986,6 +984,8 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
     - [T-Drive trajectory data sample](http://research.microsoft.com/apps/pubs/default.aspx?id=152883)
     - [USGS Remote Sensing Image](http://earthexplorer.usgs.gov/)
     - [WorldPop](http://www.worldpop.org.uk/)
+    - [Citi Bike Trip Histories](https://www.citibikenyc.com/system-data)
+    - [Crime Brasil](https://crimebrasil.com.br) - Brazilian crime incidents geocoded by neighborhood (RS, 2.99M records) and municipality (MG, RJ) with free REST API.
 
 ## News Sites
 - [canadiangis](http://canadiangis.com/)

--- a/README.md
+++ b/README.md
@@ -968,6 +968,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 
 - **Data Site**
     - [Citi Bike Trip Histories](https://www.citibikenyc.com/system-data)
+    - [Crime Brasil](https://crimebrasil.com.br) - Brazilian crime incidents geocoded by neighborhood (RS, 2.99M records) and municipality (MG, RJ) with free REST API.
     - [Geofabrik](http://download.geofabrik.de/)
     - [Geo Maps](https://github.com/simonepri/geo-maps) - High Quality GeoJSON maps programmatically generated.
     - [Global cities Shapefile data](http://download.bbbike.org/osm/bbbike/)


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) to the Data > Data Site section.

Crime Brasil provides geocoded Brazilian crime statistics:
- Rio Grande do Sul: 2.99M incidents 2022–2025, 99.99% geocoded to 79,024 neighborhoods
- Minas Gerais + Rio de Janeiro: municipality-level violent crime data
- National: PRF DATATRAN (federal highway accidents) + DATASUS SINAN

Free REST API, CSV/Parquet exports, daily updates, CC BY 4.0 license. Inserted alphabetically before Geofabrik.

Disclosure: I'm the maintainer.