### PR TITLE
Add geo-utils-cpp to C++ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [entwine](https://github.com/connormanning/entwine) - Entwine is a data organization library for massive point clouds, designed to conquer datasets of hundreds of billions of points as well as desktop-scale point clouds.
 - [GDAL](http://www.gdal.org/)  - Geospatial Data Abstraction Library (GDAL) is a computer library that serve as a translator library for raster and vector geospatial data formats.
 - [gdalcubes](https://github.com/appelmar/gdalcubes) - gdalcubes is a library to represent collections of Earth Observation (EO) images as on demand data cubes (or multidimensional arrays).
+- [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) - Header-only C++17 library for spherical (lat/lng) geometry: distance, bearing, area, point-in-polygon.
 - [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) - Port to C++ of JS GeoJSON-VT for slicing GeoJSON into vector tiles on the fly.
 - [GEOS](https://trac.osgeo.org/geos/)  - GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS).
 - [gSLICr](https://github.com/carlren/gSLICr) - Real-time super-pixel segmentation.


### PR DESCRIPTION
Adds [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) — a header-only
C++17 library for spherical (lat/lng) geometry on Earth coordinates:
distance, bearing, polygon area, point-in-polygon, and path proximity.

- License: Apache-2.0
- No runtime dependencies
- C++17, CMake 3.14+
- CI on Linux (gcc/clang), macOS, Windows; downstream `find_package`
  smoke-tested on all three

Inserted alphabetically in **Geospatial Library → C++** between
`gdalcubes` and `geojson-vt-cpp`. Complements existing entries
(`Boost Geometry`, `GEOS`, `S2 Geometry`) for use-cases that only need
lightweight spherical lat/lng calculations.

Followed `ContributingGuidelines.md`:
- [x] One link per PR
- [x] Format: `- [name](url) - Description.` ending with a period
- [x] Inserted in A–Z order within the C++ subsection
- [x] No new section needed; ToC unchanged
- [x] Searched for duplicates — none found

> Note: this PR was originally opened as `geo-utils`; the project was
> renamed to `geo-utils-cpp` to avoid a Repology naming conflict
> (see gistrec/geo-utils-cpp#11). The branch has been force-pushed
> to use the new name.