### PR TITLE
Add Sunshine Atlas to Amazing Map Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [roads to rome](http://roadstorome.moovellab.com/) - roads to ROME
 - [SCOTT REINHARD MAPS](https://scottreinhardmaps.com/)
 - [snazzymaps](https://snazzymaps.com/) - A google map style gallery
+- [Sunshine Atlas](https://sunshineatlas.com) - Interactive globe ranking 3,800+ flyable destinations by monthly sunshine hours and climate.
 - [thematicmapping](http://blog.thematicmapping.org/)
 
 ## Other


### PR DESCRIPTION
Hi — I'm the maker of Sunshine Atlas, a free, no-signup, ad-free interactive globe + open dataset (CC BY 4.0, DOI) ranking 3,833 flyable destinations by monthly sunshine hours and climate normals. Adding it under **Amazing Map Sites** because it's an interactive map site like the others in this section. Happy to tweak the wording or placement — thanks for maintaining this list!