### PR TITLE
Add World Train Map to Amazing Map Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [SCOTT REINHARD MAPS](https://scottreinhardmaps.com/)
 - [snazzymaps](https://snazzymaps.com/) - A google map style gallery
 - [thematicmapping](http://blog.thematicmapping.org/)
+- [TrainRouter](https://trainrouter.com) - Interactive atlas of 767 notable train routes across 118 countries, colour-coded by type on an OpenStreetMap basemap.
 
 ## Other
 ### Data Formats


### PR DESCRIPTION
Adds [World Train Map](https://worldtrainmap.com) to Amazing Map Sites, placed alphabetically at the end of the section.

It is a free, no-signup interactive atlas of the world's notable passenger train routes, colour-coded by type and drawn on an OpenStreetMap basemap with MapLibre GL JS. Route alignments are traced from OSM railway relations, and every route carries its distance, fastest journey time, top speed, operator and opening year.

Two notes, since this PR has been open a while and I have just pushed a change to it:

* The site was renamed and moved. It was TrainRouter at trainrouter.com when I opened this; it is now World Train Map at worldtrainmap.com. The old domain redirects, but the entry should name the live one.
* I have taken the route and country counts out of the description on purpose. The original text said 767 routes across 118 countries, and that number was already stale, which is exactly the kind of maintenance burden a list like this should not have to carry.

I built it solo, and the route dataset is open (CC BY 4.0). Thanks for the list, and sorry for the churn.