### PR TITLE
Add knowground to Amazing Map Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,7 @@ Inspired by [Awesome Python](https://github.com/vinta/awesome-python).
 - [dougmccune](http://dougmccune.com/blog/)
 - [finemapping](http://www.finemapping.com/)
 - [flowingdata](http://flowingdata.com/)
+- [knowground](https://www.knowground.com) - Free per-address lookup of US civic and environmental facts (FEMA flood zone, elevation, public schools, EPA hazards, broadband, Census), each value sourced and dated.
 - [Maps of the Year](http://homepage.ntlworld.com/keir.clarke/mapsoftheyear.htm)
 - [mapzilla](https://mapzilla.co.uk/)
 - [NC STATE UNIVERSITY Center for Geospatial Analytics](https://cnr.ncsu.edu/geospatial/)


### PR DESCRIPTION
Adds knowground (https://www.knowground.com) to Amazing Map Sites.

Disclosure: I work on knowground. It's a free, no-signup per-address lookup of US civic & environmental facts (FEMA flood zone, elevation, public schools, EPA hazards, broadband, Census), each value sourced and dated. One link added; description ends with a period per the guidelines.